### PR TITLE
fix: run all jobs after PR merge to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,7 +35,7 @@ jobs:
   service-ci:
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: needs.detect-changes.outputs.service == 'true' || github.event_name == 'pull_request'
+    if: needs.detect-changes.outputs.service == 'true' || github.ref == 'refs/heads/main' || github.event_name == 'push'
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -96,7 +96,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     needs: [detect-changes, service-ci]
-    if: needs.detect-changes.outputs.service == 'true' || github.event_name == 'pull_request'
+    if: needs.detect-changes.outputs.service == 'true' || github.ref == 'refs/heads/main' || github.event_name == 'push'
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -157,7 +157,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.service == 'true'
+    if: needs.detect-changes.outputs.service == 'true' || github.ref == 'refs/heads/main' || github.event_name == 'push'
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -192,7 +192,7 @@ jobs:
   quality-gate:
     runs-on: ubuntu-latest
     needs: [service-ci, docker-build, security-scan]
-    if: github.event_name == 'pull_request' && contains(fromJson('["main", "develop"]'), github.base_ref)
+    if: github.event_name == 'pull_request' && contains(fromJson('["main", "develop"]'), github.base_ref) || github.ref == 'refs/heads/main' || github.event_name == 'push'
     steps:
       - name: Quality Gate
         run: |
@@ -206,7 +206,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [service-ci, docker-build, security-scan]
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_run')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the workflow conditions so all jobs execute after a PR is merged to main. This ensures CI, Docker build, security scan, release, and notification jobs run as expected after merging.